### PR TITLE
Fix matchmaking random

### DIFF
--- a/src/helpers/matchmaking.ts
+++ b/src/helpers/matchmaking.ts
@@ -41,7 +41,7 @@ export async function matchmake() {
       const firstUser = users.splice(0, 1)[0]
       // Random second user
       const secondUser = users.splice(
-        Math.floor(Math.random() * (users.length - 1)),
+        Math.floor(Math.random() * users.length),
         1
       )[0]
       // Add pair


### PR DESCRIPTION
Привет, поправил рандом.

Проблема была в следующей формуле Math.floor(Math.random() * (users.length - 1)):
Math.random() возвращает число в промежутке [0, 1), т.е. включая ноль, но не включая единицу.
Затем Math.random() * (users.length - 1) - возвращает число в промежутке [0, users.length - 1).
Math.floor - окруляет число в нижнюю сторону, следовательно итоге получается число в промежутке [0, users.length - 2].

Нам же хочется получить индекс от 0 до users.length - 1

Это приводило к тому, что при нечетном количестве участников, последний вступивший всегда оставался одинок.